### PR TITLE
Fix bug alt-tabbing from mouse-captured window

### DIFF
--- a/src/Libraries/INPUT/Source/sdl_events.c
+++ b/src/Libraries/INPUT/Source/sdl_events.c
@@ -263,8 +263,7 @@ static int MouseLookY;
 //hack to keep captured mouse inside client area of window
 void KeepMouseCaptured(void)
 {
-	extern bool MouseCaptured;
-	if (MouseCaptured)
+	if (SDL_GetGrabbedWindow() == window)
 	{
 		int mx, my;		SDL_GetGlobalMouseState(&mx, &my);
 		int x, y;		SDL_GetWindowPosition(window, &x, &y);


### PR DESCRIPTION
Must detect actual mouse capture state instead of relying on global variable.